### PR TITLE
build: bump minimum Go version to 1.11.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 language: go
 go:
-- 1.8.1
+- 1.11.x
 
 install:
 # This script is used by the Travis build to install a cookie for

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.8 (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.11 (to build the provider plugin)
 
 Usage
 ---------------------
@@ -52,7 +52,7 @@ Using the provider
 Developing the Provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.8+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 


### PR DESCRIPTION
The Terraform project requires Go 1.11 already.

https://github.com/hashicorp/terraform/#developing-terraform