### PR TITLE
Fixed make command in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
-$ make bin
+$ make build
 ...
 $ $GOPATH/bin/terraform-provider-template
 ...


### PR DESCRIPTION
The makefile does not contain a bin option, this should be build instead.