### PR TITLE
vendor: Switch the hashicorp/terraform dependency to ref "pluginsdk-v0.12-early1"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ require (
 	github.com/aws/aws-sdk-go v1.16.12 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250
-	github.com/hashicorp/terraform v0.12.0-alpha4.0.20181221160614-c753df6a933e
+	github.com/hashicorp/terraform v0.12.0-alpha4.0.20190105003045-34e792db2cb5
 )

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/hashicorp/logutils v0.0.0-20150609070431-0dc08b1671f3/go.mod h1:QIAnN
 github.com/hashicorp/memberlist v0.1.0/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc3W6JvZwjxxsE=
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb h1:ZbgmOQt8DOg796figP87/EFCVx2v2h9yRvwHF/zceX4=
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
-github.com/hashicorp/terraform v0.12.0-alpha4.0.20181221160614-c753df6a933e h1:TvnxZIaVTwt1ykhMN1px5Bn/DKgeNDju0DQOxbVGWxE=
-github.com/hashicorp/terraform v0.12.0-alpha4.0.20181221160614-c753df6a933e/go.mod h1:bnpP/Uh/hRrQITfOXVPRuodgP7apCLEUSQZrFAdctg8=
+github.com/hashicorp/terraform v0.12.0-alpha4.0.20190105003045-34e792db2cb5 h1:qtb2tNzL2XtPZHNTNLgCrMfcco7duH/lB/CABwuMLWM=
+github.com/hashicorp/terraform v0.12.0-alpha4.0.20190105003045-34e792db2cb5/go.mod h1:bnpP/Uh/hRrQITfOXVPRuodgP7apCLEUSQZrFAdctg8=
 github.com/hashicorp/vault v0.0.0-20161029210149-9a60bf2a50e4 h1:SGDekHLK2IRoVS7Fb4olLyWvc2VmwKgyFC05j6X3NII=
 github.com/hashicorp/vault v0.0.0-20161029210149-9a60bf2a50e4/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=

--- a/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/user_agent.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/user_agent.go
@@ -17,7 +17,7 @@ var SDKVersionUserAgentHandler = request.NamedHandler{
 }
 
 const execEnvVar = `AWS_EXECUTION_ENV`
-const execEnvUAKey = `exec_env`
+const execEnvUAKey = `exec-env`
 
 // AddHostExecEnvUserAgentHander is a request handler appending the SDK's
 // execution environment to the user agent.

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -349,10 +349,18 @@ var awsPartition = partition{
 				},
 			},
 			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
+				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -368,6 +376,7 @@ var awsPartition = partition{
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -506,6 +515,7 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -1032,6 +1042,7 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -1206,9 +1217,13 @@ var awsPartition = partition{
 				Protocols: []string{"https"},
 			},
 			Endpoints: endpoints{
-				"eu-west-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-west-2": endpoint{},
+				"ap-northeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-2":      endpoint{},
 			},
 		},
 		"gamelift": service{
@@ -1267,6 +1282,7 @@ var awsPartition = partition{
 				"eu-west-2":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -1414,6 +1430,7 @@ var awsPartition = partition{
 				"eu-central-1": endpoint{},
 				"eu-west-1":    endpoint{},
 				"us-east-1":    endpoint{},
+				"us-east-2":    endpoint{},
 				"us-west-2":    endpoint{},
 			},
 		},
@@ -1598,6 +1615,7 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -1668,6 +1686,12 @@ var awsPartition = partition{
 		"neptune": service{
 
 			Endpoints: endpoints{
+				"ap-southeast-1": endpoint{
+					Hostname: "rds.ap-southeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
+					},
+				},
 				"eu-central-1": endpoint{
 					Hostname: "rds.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -1850,6 +1874,7 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -2306,7 +2331,7 @@ var awsPartition = partition{
 		"shield": service{
 			IsRegionalized: boxedFalse,
 			Defaults: endpoint{
-				SSLCommonName: "Shield.us-east-1.amazonaws.com",
+				SSLCommonName: "shield.us-east-1.amazonaws.com",
 				Protocols:     []string{"https"},
 			},
 			Endpoints: endpoints{
@@ -2459,6 +2484,8 @@ var awsPartition = partition{
 				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -3253,6 +3280,7 @@ var awsusgovPartition = partition{
 				},
 			},
 			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
 		},
@@ -3300,6 +3328,12 @@ var awsusgovPartition = partition{
 
 			Endpoints: endpoints{
 				"us-gov-east-1": endpoint{},
+				"us-gov-west-1": endpoint{},
+			},
+		},
+		"ds": service{
+
+			Endpoints: endpoints{
 				"us-gov-west-1": endpoint{},
 			},
 		},
@@ -3365,6 +3399,12 @@ var awsusgovPartition = partition{
 
 			Endpoints: endpoints{
 				"us-gov-east-1": endpoint{},
+				"us-gov-west-1": endpoint{},
+			},
+		},
+		"elasticfilesystem": service{
+
+			Endpoints: endpoints{
 				"us-gov-west-1": endpoint{},
 			},
 		},
@@ -3592,6 +3632,7 @@ var awsusgovPartition = partition{
 		"snowball": service{
 
 			Endpoints: endpoints{
+				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
 		},

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.16.4"
+const SDKVersion = "1.16.12"

--- a/vendor/github.com/hashicorp/terraform/terraform/state_filter.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/state_filter.go
@@ -1,0 +1,267 @@
+package terraform
+
+import (
+	"fmt"
+	"sort"
+)
+
+// StateFilter is responsible for filtering and searching a state.
+//
+// This is a separate struct from State rather than a method on State
+// because StateFilter might create sidecar data structures to optimize
+// filtering on the state.
+//
+// If you change the State, the filter created is invalid and either
+// Reset should be called or a new one should be allocated. StateFilter
+// will not watch State for changes and do this for you. If you filter after
+// changing the State without calling Reset, the behavior is not defined.
+type StateFilter struct {
+	State *State
+}
+
+// Filter takes the addresses specified by fs and finds all the matches.
+// The values of fs are resource addressing syntax that can be parsed by
+// ParseResourceAddress.
+func (f *StateFilter) Filter(fs ...string) ([]*StateFilterResult, error) {
+	// Parse all the addresses
+	as := make([]*ResourceAddress, len(fs))
+	for i, v := range fs {
+		a, err := ParseResourceAddress(v)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing address '%s': %s", v, err)
+		}
+
+		as[i] = a
+	}
+
+	// If we weren't given any filters, then we list all
+	if len(fs) == 0 {
+		as = append(as, &ResourceAddress{Index: -1})
+	}
+
+	// Filter each of the address. We keep track of this in a map to
+	// strip duplicates.
+	resultSet := make(map[string]*StateFilterResult)
+	for _, a := range as {
+		for _, r := range f.filterSingle(a) {
+			resultSet[r.String()] = r
+		}
+	}
+
+	// Make the result list
+	results := make([]*StateFilterResult, 0, len(resultSet))
+	for _, v := range resultSet {
+		results = append(results, v)
+	}
+
+	// Sort them and return
+	sort.Sort(StateFilterResultSlice(results))
+	return results, nil
+}
+
+func (f *StateFilter) filterSingle(a *ResourceAddress) []*StateFilterResult {
+	// The slice to keep track of results
+	var results []*StateFilterResult
+
+	// Go through modules first.
+	modules := make([]*ModuleState, 0, len(f.State.Modules))
+	for _, m := range f.State.Modules {
+		if f.relevant(a, m) {
+			modules = append(modules, m)
+
+			// Only add the module to the results if we haven't specified a type.
+			// We also ignore the root module.
+			if a.Type == "" && len(m.Path) > 1 {
+				results = append(results, &StateFilterResult{
+					Path:    m.Path[1:],
+					Address: (&ResourceAddress{Path: m.Path[1:]}).String(),
+					Value:   m,
+				})
+			}
+		}
+	}
+
+	// With the modules set, go through all the resources within
+	// the modules to find relevant resources.
+	for _, m := range modules {
+		for n, r := range m.Resources {
+			// The name in the state contains valuable information. Parse.
+			key, err := ParseResourceStateKey(n)
+			if err != nil {
+				// If we get an error parsing, then just ignore it
+				// out of the state.
+				continue
+			}
+
+			// Older states and test fixtures often don't contain the
+			// type directly on the ResourceState. We add this so StateFilter
+			// is a bit more robust.
+			if r.Type == "" {
+				r.Type = key.Type
+			}
+
+			if f.relevant(a, r) {
+				if a.Name != "" && a.Name != key.Name {
+					// Name doesn't match
+					continue
+				}
+
+				if a.Index >= 0 && key.Index != a.Index {
+					// Index doesn't match
+					continue
+				}
+
+				if a.Name != "" && a.Name != key.Name {
+					continue
+				}
+
+				// Build the address for this resource
+				addr := &ResourceAddress{
+					Path:  m.Path[1:],
+					Name:  key.Name,
+					Type:  key.Type,
+					Index: key.Index,
+				}
+
+				// Add the resource level result
+				resourceResult := &StateFilterResult{
+					Path:    addr.Path,
+					Address: addr.String(),
+					Value:   r,
+				}
+				if !a.InstanceTypeSet {
+					results = append(results, resourceResult)
+				}
+
+				// Add the instances
+				if r.Primary != nil {
+					addr.InstanceType = TypePrimary
+					addr.InstanceTypeSet = false
+					results = append(results, &StateFilterResult{
+						Path:    addr.Path,
+						Address: addr.String(),
+						Parent:  resourceResult,
+						Value:   r.Primary,
+					})
+				}
+
+				for _, instance := range r.Deposed {
+					if f.relevant(a, instance) {
+						addr.InstanceType = TypeDeposed
+						addr.InstanceTypeSet = true
+						results = append(results, &StateFilterResult{
+							Path:    addr.Path,
+							Address: addr.String(),
+							Parent:  resourceResult,
+							Value:   instance,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return results
+}
+
+// relevant checks for relevance of this address against the given value.
+func (f *StateFilter) relevant(addr *ResourceAddress, raw interface{}) bool {
+	switch v := raw.(type) {
+	case *ModuleState:
+		path := v.Path[1:]
+
+		if len(addr.Path) > len(path) {
+			// Longer path in address means there is no way we match.
+			return false
+		}
+
+		// Check for a prefix match
+		for i, p := range addr.Path {
+			if path[i] != p {
+				// Any mismatches don't match.
+				return false
+			}
+		}
+
+		return true
+	case *ResourceState:
+		if addr.Type == "" {
+			// If we have no resource type, then we're interested in all!
+			return true
+		}
+
+		// If the type doesn't match we fail immediately
+		if v.Type != addr.Type {
+			return false
+		}
+
+		return true
+	default:
+		// If we don't know about it, let's just say no
+		return false
+	}
+}
+
+// StateFilterResult is a single result from a filter operation. Filter
+// can match multiple things within a state (module, resource, instance, etc.)
+// and this unifies that.
+type StateFilterResult struct {
+	// Module path of the result
+	Path []string
+
+	// Address is the address that can be used to reference this exact result.
+	Address string
+
+	// Parent, if non-nil, is a parent of this result. For instances, the
+	// parent would be a resource. For resources, the parent would be
+	// a module. For modules, this is currently nil.
+	Parent *StateFilterResult
+
+	// Value is the actual value. This must be type switched on. It can be
+	// any data structures that `State` can hold: `ModuleState`,
+	// `ResourceState`, `InstanceState`.
+	Value interface{}
+}
+
+func (r *StateFilterResult) String() string {
+	return fmt.Sprintf("%T: %s", r.Value, r.Address)
+}
+
+func (r *StateFilterResult) sortedType() int {
+	switch r.Value.(type) {
+	case *ModuleState:
+		return 0
+	case *ResourceState:
+		return 1
+	case *InstanceState:
+		return 2
+	default:
+		return 50
+	}
+}
+
+// StateFilterResultSlice is a slice of results that implements
+// sort.Interface. The sorting goal is what is most appealing to
+// human output.
+type StateFilterResultSlice []*StateFilterResult
+
+func (s StateFilterResultSlice) Len() int      { return len(s) }
+func (s StateFilterResultSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s StateFilterResultSlice) Less(i, j int) bool {
+	a, b := s[i], s[j]
+
+	// if these address contain an index, we want to sort by index rather than name
+	addrA, errA := ParseResourceAddress(a.Address)
+	addrB, errB := ParseResourceAddress(b.Address)
+	if errA == nil && errB == nil && addrA.Name == addrB.Name && addrA.Index != addrB.Index {
+		return addrA.Index < addrB.Index
+	}
+
+	// If the addresses are different it is just lexographic sorting
+	if a.Address != b.Address {
+		return a.Address < b.Address
+	}
+
+	// Addresses are the same, which means it matters on the type
+	return a.sortedType() < b.sortedType()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/armon/go-radix v0.0.0-20160115234725-4239b77079c7
 github.com/armon/go-radix
-# github.com/aws/aws-sdk-go v1.16.4
+# github.com/aws/aws-sdk-go v1.16.12
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/credentials
 github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds
@@ -108,7 +108,7 @@ github.com/hashicorp/hil/parser
 github.com/hashicorp/hil/scanner
 # github.com/hashicorp/logutils v0.0.0-20150609070431-0dc08b1671f3
 github.com/hashicorp/logutils
-# github.com/hashicorp/terraform v0.12.0-alpha4.0.20181221160614-c753df6a933e
+# github.com/hashicorp/terraform v0.12.0-alpha4.0.20190105003045-34e792db2cb5
 github.com/hashicorp/terraform/plugin
 github.com/hashicorp/terraform/config
 github.com/hashicorp/terraform/helper/hashcode


### PR DESCRIPTION
This is a special "tag-like" branch upstream is using to represent a release of the SDK that is independent of the Terraform CLI even though the two codebases live together in the same repository.

Compared to the parent commit, it includes a few extra fixes from upstream but these do not affect the behavior of this provider.