### PR TITLE
Ignore missing paths during Read phase

### DIFF
--- a/template/resource_template_dir.go
+++ b/template/resource_template_dir.go
@@ -57,6 +57,17 @@ func resourceTemplateDirRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	// https://github.com/terraform-providers/terraform-provider-template/issues/19
+	// If we think we can't find the input, then either:
+	// a) it really isn't there
+	// b) the state contains a stale absolute path
+	// If the input really doesn't exist, we will still fail during the create.
+	// Mark the resource for creation without trying to checksum it.
+	if _, err := os.Stat(sourceDir); os.IsNotExist(err) {
+		d.SetId("")
+		return nil
+	}
+
 	// If the combined hash of the input and output directories is different from
 	// the stored one, mark the resource for re-creation.
 	//


### PR DESCRIPTION
When the source directory can't be found during a Read, it isn't
meaningful to try to hash it and compare the hashes. Instead we should
mark it dirty and continue to the Create step, where we will load the
source templates based on the current module location instead of the
plan contents.

Fixes terraform-providers/terraform-provider-template#19