### PR TITLE
Do no install dependencies when testing

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@ build: fmtcheck
 	go install
 
 test: fmtcheck
-	go test -i $(TEST) || exit 1
+	go test $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 


### PR DESCRIPTION
Just got into trouble when testing in a box where GOROOT != GOPATH because of this flag. It seems like it is no longer needed since Go 1.10 as per https://golang.org/doc/go1.10#build:

> The old advice to add the -i flag for speed, as in go build -i or go test -i, is no longer necessary: builds run just as fast without -i.