### PR TITLE
update syntax as vars is not a block

### DIFF
--- a/website/docs/d/cloudinit_config.html.markdown
+++ b/website/docs/d/cloudinit_config.html.markdown
@@ -28,7 +28,7 @@ featureset is specialized for the features of cloud-init.
 data "template_file" "script" {
   template = "${file("${path.module}/init.tpl")}"
 
-  vars {
+  vars = {
     consul_address = "${aws_instance.consul.private_ip}"
   }
 }


### PR DESCRIPTION
Including a `vars` argument without `=` returns the error
```
Blocks of type "vars" are not expected here. Did you mean to define argument
"vars"? If so, use the equals sign to assign it a value.
```